### PR TITLE
Interactive Mars navigation on homepage

### DIFF
--- a/about.html
+++ b/about.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mohamed Hassan - About</title>
-    <link rel="stylesheet" href="css/ style.css"> <!-- Fixed path -->
+    <link rel="stylesheet" href="css/style.css"> <!-- Fixed path -->
     <!-- Libraries -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/gsap.min.js"></script>

--- a/css/style.css
+++ b/css/style.css
@@ -47,6 +47,11 @@ body {
     z-index: -1; /* Place behind all other content */
     display: block; /* Remove potential extra space */
     background-color: var(--bg-color-dark); /* Ensure canvas has base dark color */
+    opacity: 0;
+    transition: opacity 1s ease;
+}
+body.show-3d #bg-canvas {
+    opacity: 1;
 }
 /* Removed body.light-mode #bg-canvas hiding rule */
 
@@ -133,6 +138,12 @@ section {
     margin-top: 0; /* Remove top margin for hero */
     opacity: 1; /* Make visible by default */
     transform: none;
+    transition: opacity 1s ease;
+}
+
+body.show-3d #home-content {
+    opacity: 0;
+    pointer-events: none;
 }
 
 #home-page #home-content h1 {
@@ -154,6 +165,95 @@ section {
     min-height: 40px; /* Prevent layout shift during typing */
 }
 /* Removed body.light-mode #home-page #home-content #typed-intro override */
+
+.scroll-cue {
+    margin-top: 1.5rem;
+    font-size: 1rem;
+    color: var(--accent-color-secondary);
+    animation: bounce 1.5s infinite;
+}
+
+@keyframes bounce {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-5px); }
+}
+
+/* Marker buttons positioned over canvas */
+.marker-btn {
+    position: absolute;
+    padding: 4px 8px;
+    background: rgba(0,0,0,0.7);
+    color: var(--text-color-dark);
+    border: 1px solid var(--accent-color-primary);
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    transform: translate(-50%, -50%);
+    z-index: 10;
+}
+.marker-btn:focus {
+    outline: 2px solid var(--accent-color-secondary);
+}
+
+/* Overlay dialog */
+.overlay.hidden { display: none; }
+.overlay {
+    position: fixed;
+    top: 0; left: 0; width: 100%; height: 100%;
+    background: rgba(0,0,0,0.8);
+    z-index: 2000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.overlay-content, #overlay-body {
+    max-width: 90vw;
+    max-height: 90vh;
+    overflow: auto;
+    background: var(--bg-color-dark);
+    padding: 20px;
+    border: 1px solid var(--accent-color-primary);
+    border-radius: 8px;
+    color: var(--text-color-dark);
+}
+.overlay-close {
+    position: absolute;
+    top: 10px;
+    right: 20px;
+    background: none;
+    border: none;
+    color: var(--text-color-dark);
+    font-size: 2rem;
+    cursor: pointer;
+}
+
+/* Audio toggle */
+#audio-toggle {
+    margin-left: auto;
+    background: none;
+    border: 1px solid var(--accent-color-primary);
+    color: var(--text-color-dark);
+    padding: 4px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+/* Fallback */
+.fallback.hidden { display: none; }
+.fallback {
+    position: fixed;
+    top:0; left:0; width:100%; height:100%;
+    background: var(--bg-color-dark);
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+    justify-content:center;
+    z-index:-1;
+    text-align:center;
+}
+.fallback img { max-width:80%; height:auto; }
+.fallback-links { list-style:none; padding:0; margin-top:1rem; display:flex; gap:1rem; }
+.fallback-links a { color: var(--accent-color-secondary); }
 
 /* General Section Headers & Content */
 h1, h2, h3 {
@@ -229,58 +329,6 @@ ul {
 .job ul, .project-item ul { list-style: disc; margin-left: 20px; margin-top: 0.5rem; }
 
 
-/* Orbiting Rocket Section */
-#orbit-section {
-    height: 200vh;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
-#orbit-container {
-    position: relative;
-    width: 300px;
-    height: 300px;
-}
-
-#orbit-container img#mars {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    width: 150px;
-    height: 150px;
-    transform: translate(-50%, -50%);
-    border-radius: 50%;
-}
-
-#orbit-container .orbit {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    width: 220px;
-    height: 220px;
-    margin: -110px 0 0 -110px;
-    pointer-events: none;
-}
-
-#orbit-container .orbit::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    border: 1px dashed rgba(255,255,255,0.3);
-    border-radius: 50%;
-}
-
-#orbit-container #rocket {
-    position: absolute;
-    top: 0;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    font-size: 2rem;
-}
 
 #equations {
     text-align: center;

--- a/experience.html
+++ b/experience.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mohamed Hassan - Experience</title>
-    <link rel="stylesheet" href="css/ style.css"> <!-- Fixed path -->
+    <link rel="stylesheet" href="css/style.css"> <!-- Fixed path -->
     <!-- Libraries -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/gsap.min.js"></script>

--- a/future.html
+++ b/future.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mohamed Hassan - Future Vision</title>
-    <link rel="stylesheet" href="css/ style.css"> <!-- Fixed path -->
+    <link rel="stylesheet" href="css/style.css"> <!-- Fixed path -->
     <!-- Libraries -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/gsap.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mohamed Hassan - Home</title>
-    <link rel="stylesheet" href="css/ style.css"> <!-- Fixed path -->
+    <link rel="stylesheet" href="css/style.css"> <!-- Fixed path -->
     <!-- Libraries -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <!-- Restore Libraries -->
@@ -26,11 +26,21 @@
             <li><a href="philosophy.html" class="nav-link">Philosophy</a></li>
             <li><a href="future.html" class="nav-link">Future</a></li>
         </ul>
-        <!-- Removed theme toggle button -->
+        <button id="audio-toggle" aria-label="Toggle ambient audio">🔈</button>
+        <audio id="ambient-audio" loop src="https://cdn.pixabay.com/download/audio/2023/04/01/audio_6f3dd2d7a8.mp3?filename=ambient-space-111306.mp3"></audio>
     </nav>
 
     <!-- Canvas for 3D Background -->
     <canvas id="bg-canvas"></canvas>
+    <div id="fallback" class="fallback hidden">
+        <img src="textures/mars.png" alt="Mars" />
+        <ul class="fallback-links">
+            <li><a href="about.html">About</a></li>
+            <li><a href="projects.html">Projects</a></li>
+            <li><a href="philosophy.html">Philosophy</a></li>
+            <li><a href="future.html">Future Plans</a></li>
+        </ul>
+    </div>
 
     <!-- Page-Specific Content -->
     <main>
@@ -39,17 +49,9 @@
             <p class="tagline">Physics & Astronomy Student | Aspiring Aerospace Physicist</p>
             <!-- Element for Typed.js -->
             <p><span id="typed-intro"></span></p>
+            <p class="scroll-cue">Scroll to explore</p>
             <!-- You could add the rocket SVG here again if desired -->
              <!-- <div id="rocket-container" style="margin-top: 30px; width: 60px; height: 120px;"> rocket SVG here </div> -->
-        </section>
-
-        <section id="orbit-section">
-            <div id="orbit-container">
-                <img id="mars" src="textures/mars.png" alt="Mars">
-                <div class="orbit">
-                    <div id="rocket">🚀</div>
-                </div>
-            </div>
         </section>
 
         <section id="equations">
@@ -66,6 +68,11 @@
         <p>© <span id="current-year"></span> Mohamed Hassan. All rights reserved.</p>
         <p>Built with HTML, CSS, and JavaScript. Space awaits!</p>
     </footer>
+
+    <div id="content-overlay" class="overlay hidden" role="dialog" aria-modal="true" tabindex="-1">
+        <button id="overlay-close" class="overlay-close" aria-label="Close overlay">×</button>
+        <div id="overlay-body"></div>
+    </div>
 
     <!-- Consolidated JS -->
     <script src="js/script.js" defer></script>

--- a/js/script.js
+++ b/js/script.js
@@ -8,6 +8,8 @@ document.addEventListener('DOMContentLoaded', () => {
     // initThemeToggle(); // Removed call
     updateActiveNav();
     updateFooterYear();
+    initAudioToggle();
+    initHeroScroll();
 
     // Initialize 3D Background and Animations only if motion is preferred
     if (!motionQuery.matches) {
@@ -65,12 +67,119 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    function initAudioToggle() {
+        const audio = document.getElementById('ambient-audio');
+        const btn = document.getElementById('audio-toggle');
+        if (!audio || !btn) return;
+
+        let enabled = localStorage.getItem('audioEnabled') === 'true';
+        function updateBtn() {
+            btn.textContent = enabled ? '🔊' : '🔈';
+        }
+        updateBtn();
+        if (enabled) {
+            audio.play().catch(() => { enabled = false; updateBtn(); });
+        }
+        btn.addEventListener('click', () => {
+            enabled = !enabled;
+            localStorage.setItem('audioEnabled', enabled);
+            updateBtn();
+            if (enabled) {
+                audio.play();
+            } else {
+                audio.pause();
+            }
+        });
+    }
+
+    function initHeroScroll() {
+        const hero = document.getElementById('home-content');
+        if (!hero) return;
+        const observer = new IntersectionObserver(entries => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    document.body.classList.remove('show-3d');
+                } else {
+                    document.body.classList.add('show-3d');
+                }
+            });
+        }, { threshold: 0.1 });
+        observer.observe(hero);
+    }
+
+    // Overlay handling
+    let lastFocusedElement = null;
+    function openOverlay(link) {
+        const overlay = document.getElementById('content-overlay');
+        const body = document.getElementById('overlay-body');
+        if (!overlay || !body) return;
+        overlay.classList.remove('hidden');
+        document.body.classList.add('overlay-open');
+        lastFocusedElement = document.activeElement;
+        fetch(link).then(r => r.text()).then(html => {
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(html, 'text/html');
+            const main = doc.querySelector('main') || doc.body;
+            body.innerHTML = '';
+            body.appendChild(main.cloneNode(true));
+            trapFocus(overlay);
+        });
+    }
+
+    function closeOverlay() {
+        const overlay = document.getElementById('content-overlay');
+        if (!overlay) return;
+        overlay.classList.add('hidden');
+        document.body.classList.remove('overlay-open');
+        overlay.removeEventListener('keydown', handleTrap);
+        if (lastFocusedElement) lastFocusedElement.focus();
+    }
+
+    function trapFocus(modal) {
+        const focusable = modal.querySelectorAll('a, button, textarea, input, select, [tabindex]:not([tabindex="-1"])');
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length -1];
+        function handle(e) {
+            if (e.key === 'Tab') {
+                if (e.shiftKey && document.activeElement === first) {
+                    e.preventDefault(); last.focus();
+                } else if (!e.shiftKey && document.activeElement === last) {
+                    e.preventDefault(); first.focus();
+                }
+            } else if (e.key === 'Escape') {
+                closeOverlay();
+            }
+        }
+        modal.addEventListener('keydown', handle);
+        modal.focus();
+        handleTrap = handle;
+    }
+    let handleTrap = null;
+    const closeBtn = document.getElementById('overlay-close');
+    if (closeBtn) {
+        closeBtn.addEventListener('click', closeOverlay);
+    }
+
+    function webglAvailable() {
+        try {
+            const canvas = document.createElement('canvas');
+            return !!(window.WebGLRenderingContext && (canvas.getContext('webgl') || canvas.getContext('experimental-webgl')));
+        } catch (e) {
+            return false;
+        }
+    }
+
+    function showFallback() {
+        const fb = document.getElementById('fallback');
+        if (fb) fb.classList.remove('hidden');
+    }
+
     // --- Homepage Specific Scripts ---
     function initHomepageScripts() {
         console.log("Initializing homepage scripts...");
         initHomepageAnimations();
         initTyped();
-        initOrbitScroll();
     }
 
     function initHomepageAnimations() {
@@ -119,18 +228,6 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
             console.error('Typed.js library not loaded.');
         }
-    }
-
-    function initOrbitScroll() {
-        const orbit = document.querySelector('#orbit-container .orbit');
-        if (!orbit) return;
-        window.addEventListener('scroll', () => {
-            const rotation = window.scrollY * 0.1;
-            orbit.style.transform = `rotate(${rotation}deg)`;
-            if (window.scrollY + window.innerHeight >= document.body.scrollHeight) {
-                window.scrollTo({ top: 0, behavior: 'auto' });
-            }
-        });
     }
 
     // --- ScrollTrigger Animations (Run on relevant pages) ---
@@ -185,6 +282,12 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
         console.log("Canvas element found.");
+        if (!webglAvailable()) {
+            console.warn('WebGL not supported. Showing fallback.');
+            canvas.style.display = 'none';
+            showFallback();
+            return;
+        }
 
         // --- Core Components ---
         let scene, camera, renderer;
@@ -196,6 +299,9 @@ document.addEventListener('DOMContentLoaded', () => {
         let nebulaClouds = [];
         let dustParticles;
         // let planetLights = []; // Removed planet lights array
+        let planetGroup;
+        let markers = [];
+        let domMarkers = [];
 
         // --- Interaction Variables ---
         let mouseX = 0, mouseY = 0;
@@ -240,9 +346,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 createStarfields(3);
                 console.log(`Three.js: Starfields created (${starFields.length} layers).`);
 
-                // Removed planet creation logic
-                console.log("Three.js: Skipping planet creation.");
-
+                createPlanetWithMarkers();
+                console.log("Three.js: Planet with markers created.");
 
                 console.log("Three.js: Creating nebula...");
                 createNebula(10); // Increased nebula layers
@@ -317,7 +422,58 @@ document.addEventListener('DOMContentLoaded', () => {
             console.log(`Three.js: Added ${starFields.length} starfield layers.`);
         }
 
-        // Removed createPlanets function
+        function createPlanetWithMarkers() {
+            const marsTexture = textureLoader.load('textures/mars.png');
+            planetGroup = new THREE.Group();
+            const planetGeometry = new THREE.SphereGeometry(5, 64, 64);
+            const planetMaterial = new THREE.MeshStandardMaterial({ map: marsTexture });
+            const planet = new THREE.Mesh(planetGeometry, planetMaterial);
+            planetGroup.add(planet);
+
+            const markerGeometry = new THREE.SphereGeometry(0.2, 16, 16);
+            const markerMaterial = new THREE.MeshBasicMaterial({ color: 0xffaa00 });
+
+            const sections = [
+                { lat: 20, lon: 0, link: 'about.html', label: 'About' },
+                { lat: -10, lon: 90, link: 'projects.html', label: 'Projects' },
+                { lat: 10, lon: -90, link: 'philosophy.html', label: 'Philosophy' },
+                { lat: -20, lon: 180, link: 'future.html', label: 'Future' }
+            ];
+
+            sections.forEach(s => {
+                const marker = new THREE.Mesh(markerGeometry, markerMaterial.clone());
+                marker.position.copy(latLonToVector(5.2, s.lat, s.lon));
+                marker.userData.link = s.link;
+                planetGroup.add(marker);
+                markers.push(marker);
+
+                const btn = document.createElement('button');
+                btn.className = 'marker-btn';
+                btn.textContent = s.label;
+                btn.setAttribute('data-link', s.link);
+                btn.addEventListener('click', () => openOverlay(s.link));
+                btn.addEventListener('keydown', e => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        openOverlay(s.link);
+                    }
+                });
+                document.body.appendChild(btn);
+                domMarkers.push({ element: btn, mesh: marker });
+            });
+
+            scene.add(planetGroup);
+        }
+
+        function latLonToVector(radius, lat, lon) {
+            const phi = (90 - lat) * (Math.PI / 180);
+            const theta = (lon + 180) * (Math.PI / 180);
+
+            const x = -radius * Math.sin(phi) * Math.cos(theta);
+            const y = radius * Math.cos(phi);
+            const z = radius * Math.sin(phi) * Math.sin(theta);
+            return new THREE.Vector3(x, y, z);
+        }
 
         function createNebula(numClouds) {
              // ** Using local texture(s) from 'textures/' folder **
@@ -407,6 +563,8 @@ document.addEventListener('DOMContentLoaded', () => {
             scrollYPos = window.scrollY;
         }
 
+        // Removed canvas click navigation in favor of DOM buttons
+
         function onWindowResize() {
             if (!camera || !renderer) return; // Check if components are initialized
 
@@ -453,8 +611,9 @@ document.addEventListener('DOMContentLoaded', () => {
                     dustParticles.rotation.x += delta * dustParticles.userData.rotationSpeed * 0.5;
                 }
 
-                // Removed planet light following logic
-
+                if (planetGroup) {
+                    planetGroup.rotation.y += delta * 0.2;
+                }
 
                 // Camera Z position based on scroll (Parallax effect)
                 // Adjust multiplier and max Z based on new scene depth and starting Z
@@ -468,6 +627,16 @@ document.addEventListener('DOMContentLoaded', () => {
                 // Subtle Camera Tilt based on Mouse (Lerp)
                 camera.rotation.x += (targetRotX - camera.rotation.x) * 0.05; // Smooth lerp towards target
                 camera.rotation.y += (targetRotY - camera.rotation.y) * 0.05;
+
+                // Update DOM marker positions
+                domMarkers.forEach(obj => {
+                    const vector = obj.mesh.position.clone();
+                    vector.project(camera);
+                    const x = (vector.x * 0.5 + 0.5) * window.innerWidth;
+                    const y = (-vector.y * 0.5 + 0.5) * window.innerHeight;
+                    obj.element.style.left = `${x}px`;
+                    obj.element.style.top = `${y}px`;
+                });
 
                 // Render the scene
                 if (renderer && scene && camera) {

--- a/philosophy.html
+++ b/philosophy.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mohamed Hassan - Philosophy</title>
-    <link rel="stylesheet" href="css/ style.css"> <!-- Fixed path -->
+    <link rel="stylesheet" href="css/style.css"> <!-- Fixed path -->
     <!-- Libraries -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/gsap.min.js"></script>

--- a/projects.html
+++ b/projects.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mohamed Hassan - Projects</title>
-    <link rel="stylesheet" href="css/ style.css"> <!-- Fixed path -->
+    <link rel="stylesheet" href="css/style.css"> <!-- Fixed path -->
     <!-- Libraries -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/gsap.min.js"></script>


### PR DESCRIPTION
## Summary
- add hero fade and 3D canvas fade-in for smoother scroll transition
- introduce accessible Mars markers that open overlay dialogs for About, Projects, Philosophy, and Future sections
- add ambient audio toggle and static fallback when WebGL is unavailable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bbd1cc3448328a9fe42fe60824182